### PR TITLE
Fixed problem in which GAF go term was not in the closure lookup

### DIFF
--- a/bin/scrape-gaf.js
+++ b/bin/scrape-gaf.js
@@ -111,7 +111,10 @@ init_promise
                       var has_term = false
                       id_alias_term[2].forEach (function (gterm) {
                         terms.forEach (function (term) {
-                          if (in_term_closure[gterm][term])
+                          if (!in_term_closure[gterm]) {
+                              console.warn("No term closure for "+gterm)
+                          }
+                          if (in_term_closure[gterm] && in_term_closure[gterm][term])
                             has_term = found_term[term] = true
                         })
                       })


### PR DESCRIPTION
These should be rare. In latest run over all GAFs we see

No term closure for GO:0140253
No term closure for GO:0140253
No term closure for GO:0140253
No term closure for GO:0140253

In theory this should never happen but we have been
rejigging the GO pipeline and may be more liberal with
GAF filtering than we have been.

The fix is to exclude these